### PR TITLE
plugin_proxy: pass ctx to input golang plugins

### DIFF
--- a/include/fluent-bit/flb_plugin_proxy.h
+++ b/include/fluent-bit/flb_plugin_proxy.h
@@ -56,15 +56,10 @@ struct flb_plugin_proxy {
 
 /* This is the context for proxy plugins */
 struct flb_plugin_proxy_context {
+    int coll_fd;
     /* This context is set by the remote init and is passed to remote flush */
     void *remote_context;
     /* A proxy ptr is needed to detect the proxy type/lang (OUTPUT/GOLANG) */
-    struct flb_plugin_proxy *proxy;
-};
-
-struct flb_plugin_input_proxy_context {
-    int coll_fd;
-    /* A proxy ptr is needed to store the proxy type/lang (OUTPUT/GOLANG) */
     struct flb_plugin_proxy *proxy;
 };
 

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -1537,7 +1537,7 @@ retry_request:
         flb_plg_debug(ctx->ins, "PutLogEvents http status=%d", c->resp.status);
 
         if (c->resp.status == 200) {
-            if (c->resp.data == NULL || c->resp.data_len == 0 || strcasestr(c->resp.data, AMZN_REQUEST_ID_HEADER) == NULL) {
+            if (c->resp.data == NULL || c->resp.data_len == 0 || strcasecmp(c->resp.data, AMZN_REQUEST_ID_HEADER) == NULL) {
                 /* code was 200, but response is invalid, treat as failure */
                 if (c->resp.data != NULL && c->resp.data_len > 0) {
                     flb_plg_debug(ctx->ins, "Invalid response: full data: `%.*s`", (int) c->resp.data_len, c->resp.data);

--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -76,12 +76,12 @@ static int flb_proxy_input_cb_collect(struct flb_input_instance *ins,
     int ret = FLB_OK;
     size_t len = 0;
     void *data = NULL;
-    struct flb_plugin_input_proxy_context *ctx = (struct flb_plugin_input_proxy_context *) in_context;
+    struct flb_plugin_proxy_context *ctx = (struct flb_plugin_proxy_context *) in_context;
 
 #ifdef FLB_HAVE_PROXY_GO
     if (ctx->proxy->def->proxy == FLB_PROXY_GOLANG) {
         flb_trace("[GO] entering go_collect()");
-        ret = proxy_go_input_collect(ctx->proxy, &data, &len);
+        ret = proxy_go_input_collect(ctx, &data, &len);
 
         if (len == 0) {
             flb_trace("[GO] No logs are ingested");
@@ -110,11 +110,11 @@ static int flb_proxy_input_cb_init(struct flb_input_instance *ins,
                                    struct flb_config *config, void *data)
 {
     int ret = -1;
-    struct flb_plugin_input_proxy_context *ctx;
+    struct flb_plugin_proxy_context *ctx;
     struct flb_plugin_proxy_context *pc;
 
     /* Allocate space for the configuration context */
-    ctx = flb_malloc(sizeof(struct flb_plugin_input_proxy_context));
+    ctx = flb_malloc(sizeof(struct flb_plugin_proxy_context));
     if (!ctx) {
         flb_errno();
         return -1;
@@ -171,7 +171,7 @@ init_error:
 
 static void flb_proxy_input_cb_pause(void *data, struct flb_config *config)
 {
-    struct flb_plugin_input_proxy_context *ctx = data;
+    struct flb_plugin_proxy_context *ctx = data;
     struct flb_plugin_proxy *proxy = (ctx->proxy);
 
     /* pause */
@@ -187,7 +187,7 @@ static void flb_proxy_input_cb_pause(void *data, struct flb_config *config)
 
 static void flb_proxy_input_cb_resume(void *data, struct flb_config *config)
 {
-    struct flb_plugin_input_proxy_context *ctx = data;
+    struct flb_plugin_proxy_context *ctx = data;
     struct flb_plugin_proxy *proxy = (ctx->proxy);
 
     /* resume */
@@ -251,7 +251,7 @@ static void flb_proxy_output_cb_destroy(struct flb_output_plugin *plugin)
 
 static int flb_proxy_input_cb_exit(void *in_context, struct flb_config *config)
 {
-    struct flb_plugin_input_proxy_context *ctx = in_context;
+    struct flb_plugin_proxy_context *ctx = in_context;
     struct flb_plugin_proxy *proxy = (ctx->proxy);
     /* pre_exit (Golang plugin only) */
     void (*cb_pre_exit)(int);

--- a/src/proxy/go/go.h
+++ b/src/proxy/go/go.h
@@ -44,6 +44,7 @@ struct flbgo_input_plugin {
 
     int (*cb_init)();
     int (*cb_collect)(void **, size_t *);
+    int (*cb_collect_ctx)(void *, void **, size_t *);
     int (*cb_cleanup)(void *);
     int (*cb_exit)();
 };
@@ -63,10 +64,10 @@ int proxy_go_input_register(struct flb_plugin_proxy *proxy,
                             struct flb_plugin_proxy_def *def);
 
 int proxy_go_input_init(struct flb_plugin_proxy *proxy);
-int proxy_go_input_collect(struct flb_plugin_proxy *ctx,
+int proxy_go_input_collect(struct flb_plugin_proxy_context *ctx,
                            void **collected_data, size_t *len);
 int proxy_go_input_cleanup(struct flb_plugin_proxy *ctx,
                            void *allocated_data);
-int proxy_go_input_destroy(struct flb_plugin_input_proxy_context *ctx);
+int proxy_go_input_destroy(struct flb_plugin_proxy_context *ctx);
 void proxy_go_input_unregister(void *data);
 #endif


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
